### PR TITLE
Add find families button

### DIFF
--- a/Client/Pages/RegisterSinglePerson.razor
+++ b/Client/Pages/RegisterSinglePerson.razor
@@ -16,12 +16,13 @@
     </div>
     <div class="mb-3">
         <label for="town" class="form-label">Town</label>
-        <InputText id="town" class="form-control" @bind-Value="newSinglePerson.Town" @onchange="FetchAvailableFamilies" />
+        <InputText id="town" class="form-control" @bind-Value="newSinglePerson.Town" />
     </div>
     <div class="mb-3">
         <label for="age" class="form-label">Age</label>
         <InputNumber id="age" class="form-control" @bind-Value="newSinglePerson.Age" />
     </div>
+    <button type="button" class="btn btn-secondary" @onclick="FetchAvailableFamilies">Find Families</button>
     <div class="mb-3">
         <label for="family" class="form-label">Family</label>
         <InputSelect id="family" class="form-control" @bind-Value="selectedFamilyId">
@@ -70,12 +71,11 @@ else if (registrationAttempted)
         registrationAttempted = true;
     }
 
-    private async Task FetchAvailableFamilies(ChangeEventArgs e)
+    private async Task FetchAvailableFamilies()
     {
-        var town = e.Value?.ToString();
-        if (!string.IsNullOrEmpty(town))
+        if (!string.IsNullOrEmpty(newSinglePerson.Town))
         {
-            availableFamilies = await Http.GetFromJsonAsync<List<Family>>($"api/availablefamilies/{town}");
+            availableFamilies = await Http.GetFromJsonAsync<List<Family>>($"api/availablefamilies/{newSinglePerson.Town}");
         }
     }
 


### PR DESCRIPTION
Related to #9

Add a button to explicitly find families in the registration form for single persons.

* Add a "Find Families" button to `Client/Pages/RegisterSinglePerson.razor` to trigger the family search.
* Modify the `FetchAvailableFamilies` method to be triggered by the button click instead of the input change event.
* Remove the `@onchange` event from the town input field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/ChristmasDinnerTryout2/pull/10?shareId=d6964a19-6042-4229-82d7-4d4a3125f260).