### PR TITLE
Refactor shared classes into a separate project

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -19,6 +19,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Api/FamilyFunction.cs
+++ b/Api/FamilyFunction.cs
@@ -3,9 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
-using Api.Models;
 using Api.Services;
 using System.Linq;
+using Shared.Models;
 
 namespace Api
 {

--- a/Api/Services/FamilyService.cs
+++ b/Api/Services/FamilyService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
-using Api.Models;
+using Shared.Models;
 
 namespace Api.Services
 {

--- a/Api/Services/SinglePersonService.cs
+++ b/Api/Services/SinglePersonService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
-using Api.Models;
+using Shared.Models;
 
 namespace Api.Services
 {

--- a/ChristmasDinner.sln
+++ b/ChristmasDinner.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api", "Api\Api.csproj", "{65EE3C03-CB69-4FC0-9ACA-1228F7930340}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{E234066D-7CA5-47F8-823C-880DF8B0EC32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{65EE3C03-CB69-4FC0-9ACA-1228F7930340}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65EE3C03-CB69-4FC0-9ACA-1228F7930340}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65EE3C03-CB69-4FC0-9ACA-1228F7930340}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E234066D-7CA5-47F8-823C-880DF8B0EC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E234066D-7CA5-47F8-823C-880DF8B0EC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E234066D-7CA5-47F8-823C-880DF8B0EC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E234066D-7CA5-47F8-823C-880DF8B0EC32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Client/Pages/AddFamily.razor
+++ b/Client/Pages/AddFamily.razor
@@ -1,6 +1,8 @@
-﻿@page "/addfamily"
+@page "/addfamily"
 
 @inject HttpClient Http
+
+@using Shared.Models
 
 <PageTitle>Add family</PageTitle>
 
@@ -47,24 +49,5 @@
     {
         await Http.PostAsJsonAsync("api/addfamily", newFamily);
         newFamily = new Family();
-    }
-
-    public class Family
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public string Town { get; set; } = string.Empty;
-        public int NumberOfPersons { get; set; }
-        public int NumberOfChildren { get; set; }
-        public int NumberOfSeats { get; set; }
-
-        public List<Guest> Guests { get; set; } = new List<Guest>();
-    }
-
-    public class Guest
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public int Age { get; set; }
     }
 }

--- a/Client/Pages/Families.razor
+++ b/Client/Pages/Families.razor
@@ -2,6 +2,8 @@
 
 @inject HttpClient Http
 
+@using Shared.Models
+
 <PageTitle>Families</PageTitle>
 
 <h1>Families</h1>
@@ -32,7 +34,7 @@ else
                     <td>@family.NumberOfPersons</td>
                     <td>@family.NumberOfChildren</td>
                     <td>@family.NumberOfSeats</td>
-                    <td>@family.NumberOfGuests</td>
+                    <td>@family.Guests.Count</td>
                 </tr>
             }
         </tbody>
@@ -45,26 +47,5 @@ else
     protected override async Task OnInitializedAsync()
     {
         families = await Http.GetFromJsonAsync<List<Family>>("api/getfamily");
-    }
-
-    public class Family
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public string Town { get; set; } = string.Empty;
-        public int NumberOfPersons { get; set; }
-        public int NumberOfChildren { get; set; }
-        public int NumberOfSeats { get; set; }
-
-        public int NumberOfGuests => Guests.Count;
-
-        public List<Guest> Guests { get; set; } = new List<Guest>();
-    }
-
-    public class Guest
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public int Age { get; set; }
     }
 }

--- a/Client/Pages/RegisterSinglePerson.razor
+++ b/Client/Pages/RegisterSinglePerson.razor
@@ -2,6 +2,8 @@
 
 @inject HttpClient Http
 
+@using Shared.Models
+
 <PageTitle>Register Single Person</PageTitle>
 
 <h1>Register Single Person</h1>
@@ -29,7 +31,7 @@
             <option value="">Select a family</option>
             @foreach (var family in availableFamilies)
             {
-                <option value="@family.Id">@family.Name</option>
+                <option value="@family.id">@family.Name</option>
             }
         </InputSelect>
     </div>
@@ -78,30 +80,4 @@ else if (registrationAttempted)
             availableFamilies = await Http.GetFromJsonAsync<List<Family>>($"api/GetFamiliesByTown?town={newSinglePerson.Town}");
         }
     }
-
-    public class SinglePerson
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public string Town { get; set; } = string.Empty;
-        public int Age { get; set; }
-        public string FamilyId { get; set; } = string.Empty;
-    }
-
-    public class Family
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public string Town { get; set; } = string.Empty;
-        public int NumberOfSeats { get; set; }
-        public List<Guest> Guests { get; set; } = new List<Guest>();
-    }
-
-    public class Guest
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public int Age { get; set; }
-    }
 }
-

--- a/Shared/Class1.cs
+++ b/Shared/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace Shared;
+
+public class Class1
+{
+
+}

--- a/Shared/Models/Family.cs
+++ b/Shared/Models/Family.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Api.Models
+namespace Shared.Models
 {
     public class Family
     {

--- a/Shared/Models/SinglePerson.cs
+++ b/Shared/Models/SinglePerson.cs
@@ -1,4 +1,4 @@
-namespace Api.Models
+namespace Shared.Models
 {
     public class SinglePerson
     {

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Related to #13

Move shared classes to a new project to avoid duplication.

* Create a new .NET 9 class library project `Shared` for shared classes.
* Move `Family` and `Guest` classes from `Api/Models/Family.cs` to `Shared/Models/Family.cs`.
* Move `SinglePerson` class from `Api/Models/SinglePerson.cs` to `Shared/Models/SinglePerson.cs`.
* Delete `Api/Models/Family.cs` and `Api/Models/SinglePerson.cs`.
* Update `Client/Pages/AddFamily.razor` to remove duplicate definitions of `Family` and `Guest` classes and add a using directive for `Shared.Models`.
* Update `Client/Pages/Families.razor` to remove duplicate definitions of `Family` and `Guest` classes, add a using directive for `Shared.Models`, and fix the `NumberOfGuests` property.
* Update `Client/Pages/RegisterSinglePerson.razor` to remove duplicate definitions of `Family`, `Guest`, and `SinglePerson` classes and add a using directive for `Shared.Models`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/ChristmasDinner/pull/14?shareId=02a48122-6cda-4259-a211-d8011ee1f3e8).